### PR TITLE
Move textures into a texture storage instead of stored as reference on entities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,19 @@ name = "rustgame"
 version = "0.1.0"
 dependencies = [
  "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "os_type 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -25,6 +34,15 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lazy_static"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +51,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num"
@@ -67,6 +93,14 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "os_type"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,6 +112,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sdl2"
@@ -144,22 +195,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum dtoa 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5edd69c67b2f8e0911629b7e6b8a34cb3956613cd7c6e6414966dee349c2db4f"
 "checksum itoa 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91fd9dc2c587067de817fec4ad355e3818c3d893a78cab32a0a474c7a15bb8d5"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum num 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "bde7c03b09e7c6a301ee81f6ddf66d7a28ec305699e3d3b056d2fc56470e3120"
 "checksum num-integer 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "fb24d9bfb3f222010df27995441ded1e954f8f69cd35021f6bef02ca9552fb92"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
+"checksum os_type 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29a516da97a703e47d64b16eed2d3ebf9e732694a73ec08c005173e85a2c1940"
 "checksum quote 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "e7b44fd83db28b83c1c58187159934906e5e955c812e211df413b76b03c909a5"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum sdl2 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29301273acc73295e4864a069bf9ad791ef0f819f4fc2a4653aa55818f1cbb05"
 "checksum sdl2-sys 0.27.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37cfe343db4cd2159cab098096fff52e92d513c2a5b1ee06abbfd5db5323a64d"
 "checksum serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0ae9a3c8b07c09dbe43022486d55a18c629a0618d2241e49829aaef9b6d862f9"
@@ -167,4 +256,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ecc6e0379ca933ece58302d2d3034443f06fbf38fd535857c1dc516195cbc3bf"
 "checksum serde_json 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cf37ce931677e98b4fa5e6469aaa3ab4b6228309ea33b1b22d3ec055adfc4515"
 "checksum syn 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f4f94368aae82bb29656c98443a7026ca931a659e8d19dcdc41d6e273054e820"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ build = "src/build.rs"
 serde = "0.9"
 serde_derive = "0.9"
 serde_json = "0.9"
+os_type="0.5.0"
 
 [dependencies]
 num-traits = "0.1.36"

--- a/src/anim.rs
+++ b/src/anim.rs
@@ -9,13 +9,12 @@ use ase::*;
 
 // Represents a set of animations and what is currently playing
 pub struct SpriteAnimator<'a> {
-    sheet: &'a Sheet,
-    playback: RefCell<Playback>,
+    pub sheet: &'a Sheet,
+    pub playback: RefCell<Playback>,
 }
 
 // Represents an .ase file, or a set of animations
 pub struct Sheet {
-    pub image: Texture,
     pub name: String,
     pub anims: HashMap<String, Vec<Frame>>,
 }
@@ -23,35 +22,12 @@ pub struct Sheet {
 // Represents the current playback state of an animator instance
 #[derive(Debug, Clone)]
 pub struct Playback {
-    current_anim: String,
-    duration: f32,
-    current_frame_index: usize,
+    pub current_anim: String,
+    pub duration: f32,
+    pub current_frame_index: usize,
 }
 
 impl<'a> SpriteAnimator<'a> {
-    pub fn render(&self, x: i32, y: i32, zoom: u32, dt: f32, renderer: &mut Renderer) {
-        self.update_frame_index(dt);
-
-        let ref playback = self.playback.borrow();
-        let ref current_frame = self.sheet.anims[&playback.current_anim]
-            .get(playback.current_frame_index as usize)
-            .unwrap()
-            .frame;
-        let source_rect = Rect::new(current_frame.x,
-                                    current_frame.y,
-                                    current_frame.w,
-                                    current_frame.h);
-        let mut dest_rect = Rect::new(current_frame.x,
-                                      current_frame.y,
-                                      current_frame.w * zoom,
-                                      current_frame.h * zoom);
-        dest_rect.center_on(Point::new(x, y));
-        renderer.copy(&self.sheet.image, Some(source_rect), Some(dest_rect))
-            .expect("Render failed");
-        renderer.present();
-        renderer.clear();
-    }
-
     pub fn update_frame_index(&self, dt: f32) {
         let ref mut playback = self.playback.borrow_mut();
         playback.duration += dt * 1000.0;
@@ -75,7 +51,6 @@ fn _get_current_frame_duration(index: usize, current_anim: &Vec<Frame>) -> f32 {
 
 pub fn import_sheet(filename: &str, renderer: &Renderer) -> Sheet {
     let aseprite = import(filename);
-    let image = renderer.load_texture(Path::new(&aseprite.meta.image)).unwrap();
     let mut anim_map = HashMap::new();
 
     for anim in &aseprite.meta.frameTags {
@@ -91,7 +66,6 @@ pub fn import_sheet(filename: &str, renderer: &Renderer) -> Sheet {
     }
 
     return Sheet {
-        image: image,
         name: filename.to_string(),
         anims: anim_map,
     };

--- a/src/build.rs
+++ b/src/build.rs
@@ -67,10 +67,10 @@ fn decide_if_needs_rebuilt(file: &AseFile) -> bool {
         AseFile { ase: None, .. } => {
             // If we don't have an .ase file, then there's nothing to build
             return false;
-        }
+        },
         _ => {
             return true;
-        }
+        },
     }
 }
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,3 +1,5 @@
+extern crate os_type;
+
 use std::fs;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -77,7 +79,11 @@ pub fn main() {
     for os_filename in needs_rebuilt_list {
         let filename = os_filename.to_str().unwrap();
         let json_file_name = format!("assets/{}.json", filename);
-        ::std::process::Command::new("aseprite")
+        let aseprite_command = match os_type::current_platform() {
+            os_type::OSType::Windows => "C:/Program Files (x86)/Aseprite/Aseprite.exe",
+            _ => "aseprite"
+        };
+        ::std::process::Command::new(aseprite_command)
                 .arg(format!("assets/{}.ase", filename))
                 .arg("--sheet")
                 .arg(format!("assets/{}.png", filename))

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -16,7 +16,7 @@ impl<'a> Graphics<'a> {
         return Graphics {
             textures: HashMap::new(),
             renderer: renderer,
-        }
+        };
     }
 
     pub fn load_texture(&mut self, texture_path: String) {
@@ -24,7 +24,13 @@ impl<'a> Graphics<'a> {
         self.textures.insert(texture_path, image);
     }
 
-    pub fn render(&mut self, texture_path: &String, animator: &SpriteAnimator, x: i32, y: i32, zoom: u32, dt: f32) {
+    pub fn render(&mut self,
+                  texture_path: &String,
+                  animator: &SpriteAnimator,
+                  x: i32,
+                  y: i32,
+                  zoom: u32,
+                  dt: f32) {
         animator.update_frame_index(dt);
         let ref playback = animator.playback.borrow();
         let ref current_frame = animator.sheet.anims[&playback.current_anim]

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,0 +1,48 @@
+use std::collections::HashMap;
+use std::path::Path;
+use sdl2::rect::Rect;
+use sdl2::rect::Point;
+use sdl2::image::*;
+use sdl2::render::*;
+use anim::SpriteAnimator;
+
+pub struct Graphics<'a> {
+    pub textures: HashMap<String, Texture>,
+    pub renderer: Renderer<'a>,
+}
+
+impl<'a> Graphics<'a> {
+    pub fn new(renderer: Renderer<'a>) -> Graphics<'a> {
+        return Graphics {
+            textures: HashMap::new(),
+            renderer: renderer,
+        }
+    }
+
+    pub fn load_texture(&mut self, texture_path: String) {
+        let image = self.renderer.load_texture(Path::new(&texture_path)).unwrap();
+        self.textures.insert(texture_path, image);
+    }
+
+    pub fn render(&mut self, texture_path: &String, animator: &SpriteAnimator, x: i32, y: i32, zoom: u32, dt: f32) {
+        animator.update_frame_index(dt);
+        let ref playback = animator.playback.borrow();
+        let ref current_frame = animator.sheet.anims[&playback.current_anim]
+            .get(playback.current_frame_index as usize)
+            .unwrap()
+            .frame;
+        let source_rect = Rect::new(current_frame.x,
+                                    current_frame.y,
+                                    current_frame.w,
+                                    current_frame.h);
+        let mut dest_rect = Rect::new(current_frame.x,
+                                      current_frame.y,
+                                      current_frame.w * zoom,
+                                      current_frame.h * zoom);
+        dest_rect.center_on(Point::new(x, y));
+        let ref texture = self.textures.get(texture_path).unwrap();
+        self.renderer.copy(texture, Some(source_rect), Some(dest_rect)).expect("Render failed");
+        self.renderer.present();
+        self.renderer.clear();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,12 +5,15 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate sdl2;
 
+use std::collections::HashMap;
 use sdl2::pixels::Color;
 use sdl2::event::Event;
 use sdl2::image::*;
 use sdl2::keyboard::Keycode;
+use graphics::Graphics;
 mod anim;
 mod ase;
+mod graphics;
 
 const SCREEN_FPS: u32 = 60;
 const SCREEN_TICKS_PER_FRAME: u32 = 1000 / SCREEN_FPS;
@@ -32,12 +35,18 @@ pub fn main() {
     renderer.set_draw_color(Color::RGB(255, 255, 255));
     renderer.clear();
     renderer.present();
+
+    let mut graphics = Graphics::new(renderer);
+
     let mut event_pump = sdl_context.event_pump().unwrap();
 
     let mut timer = sdl_context.timer().unwrap();
 
-    let sheet = anim::import_sheet("character_idle", &renderer);
+    let sheet = anim::import_sheet("character_idle", &graphics.renderer);
     let animator = anim::get_animator(&sheet);
+    graphics.load_texture("assets/character_idle.png".to_string());
+
+    let character_idle_path = "assets/character_idle.png".to_string();
 
     let mut dt = 0.0;
     let mut keep_playing = true;
@@ -53,7 +62,7 @@ pub fn main() {
         }
         let start_ticks = timer.ticks();
 
-        animator.render(100, 100, 2, dt, &mut renderer);
+        graphics.render(&character_idle_path, &animator, 100, 100, 2, dt);
 
         dt = sleep_til_next_frame(&mut timer, start_ticks);
     }

--- a/src/myecs.rs
+++ b/src/myecs.rs
@@ -1,0 +1,62 @@
+use std::cell::Cell;
+use ecs::*;
+use ecs::system::*;
+use anim::*;
+
+/*
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Animator<'a> {
+    pub spriteAnimator: SpriteAnimator<'a>
+}
+*/
+
+components! {
+    struct MyComponents {
+        //#[hot] animator: Animator<'a>,
+    }
+}
+
+#[derive(Default)]
+pub struct DeltaService {
+    pub time: Cell<f32>,
+}
+
+#[derive(Default)]
+pub struct MyServices {
+    pub delta: DeltaService,
+}
+
+impl ServiceManager for MyServices {
+}
+
+pub struct MotionProcess;
+
+impl System for MotionProcess { type Components = MyComponents; type Services = MyServices; }
+
+impl EntityProcess for MotionProcess {
+    fn process(&mut self, entities: EntityIter<MyComponents>, data: &mut DataHelper<MyComponents, MyServices>) {
+        /*
+        for e in entities {
+            let mut position = data.position[e];
+            let velocity = data.velocity[e];
+            position.x += velocity.dx * data.services.delta.time.get();
+            position.y += velocity.dy * data.services.delta.time.get();
+            data.position[e] = position;
+        }
+        */
+    }
+}
+
+systems! {
+    struct MySystems<MyComponents, MyServices> {
+        active: {
+            /*
+            motion: EntitySystem<MotionProcess> = EntitySystem::new(
+                MotionProcess,
+                aspect!(<MyComponents> all: [position, velocity])
+            ),
+            */
+        },
+        passive: {}
+    }
+}


### PR DESCRIPTION
Removing references to textures from our entities will allow us to serialize them into data objects which are human readable and give us more control over when textures are loaded into memory.